### PR TITLE
Small improvements & 1.20 Compatibility

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -25,7 +25,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -60,44 +60,12 @@
       <artifactId>bungeecord-api</artifactId>
       <version>1.7-SNAPSHOT</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>bungeecord-chat</artifactId>
-          <groupId>net.md-5</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>bungeecord-config</artifactId>
-          <groupId>net.md-5</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>bungeecord-event</artifactId>
-          <groupId>net.md-5</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>bungeecord-protocol</artifactId>
-          <groupId>net.md-5</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>guava</artifactId>
-          <groupId>com.google.guava</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>trove4j</artifactId>
-          <groupId>net.sf.trove4j</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.cubespace</groupId>
       <artifactId>Yamler-Core</artifactId>
       <version>2.4.0-SNAPSHOT</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>snakeyaml</artifactId>
-          <groupId>org.yaml</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -106,9 +74,15 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>8.0.33</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.7.15-M1</version>
+      <version>3.42.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,12 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.25</version>
+			<version>8.0.33</version>
 		</dependency>
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.7.15-M1</version>
+			<version>3.42.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/fr/Alphart/BAT/BAT.java
+++ b/src/main/java/fr/Alphart/BAT/BAT.java
@@ -3,6 +3,7 @@ package fr.Alphart.BAT;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.channels.Channels;
@@ -226,9 +227,18 @@ public class BAT extends Plugin {
 		}
 
 		// Load the driver
-		try (URLClassLoader classLoader = new URLClassLoader(new URL[]{driverPath.toURI().toURL()})) {
-			classLoader.loadClass("org.sqlite.JDBC");
-			Class.forName("org.sqlite.JDBC");//, true, classLoader);
+		try {
+			URLClassLoader systemClassLoader;
+			URL u;
+			Class<URLClassLoader> sysclass;
+			u = driverPath.toURI().toURL();
+			systemClassLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+			sysclass = URLClassLoader.class;
+			final Method method = sysclass.getDeclaredMethod("addURL", URL.class);
+			method.setAccessible(true);
+			method.invoke(systemClassLoader, u);
+
+			Class.forName("org.sqlite.JDBC");
 			return true;
 		} catch (final Throwable t) {
 			getLogger().severe("The sqlite driver cannot be loaded. Please report this error : ");

--- a/src/main/java/fr/Alphart/BAT/BAT.java
+++ b/src/main/java/fr/Alphart/BAT/BAT.java
@@ -3,7 +3,6 @@ package fr.Alphart.BAT;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.channels.Channels;
@@ -227,18 +226,9 @@ public class BAT extends Plugin {
 		}
 
 		// Load the driver
-		try {
-			URLClassLoader systemClassLoader;
-			URL u;
-			Class<URLClassLoader> sysclass;
-			u = driverPath.toURI().toURL();
-			systemClassLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
-			sysclass = URLClassLoader.class;
-			final Method method = sysclass.getDeclaredMethod("addURL", new Class[] { URL.class });
-			method.setAccessible(true);
-			method.invoke(systemClassLoader, new Object[] { u });
-
-			Class.forName("org.sqlite.JDBC");
+		try (URLClassLoader classLoader = new URLClassLoader(new URL[]{driverPath.toURI().toURL()})) {
+			classLoader.loadClass("org.sqlite.JDBC");
+			Class.forName("org.sqlite.JDBC");//, true, classLoader);
 			return true;
 		} catch (final Throwable t) {
 			getLogger().severe("The sqlite driver cannot be loaded. Please report this error : ");

--- a/src/main/java/fr/Alphart/BAT/BAT.java
+++ b/src/main/java/fr/Alphart/BAT/BAT.java
@@ -61,7 +61,7 @@ public class BAT extends Plugin {
 		getLogger().setLevel(Level.INFO);
 		if (!ProxyServer.getInstance().getName().equals("BungeeCord")) {
 		  getLogger().warning("BungeeCord version check disabled because a fork has been detected."
-              + " Make sur your fork is based on a BungeeCord build > #" + requiredBCBuild);
+              + " Make sure your fork is based on a BungeeCord build > #" + requiredBCBuild);
 		}
 		else if(getBCBuild() < requiredBCBuild && !new File(getDataFolder(), "skipversiontest").exists()){
 		  getLogger().severe("Your BungeeCord build (#" + getBCBuild() + ") is not supported. Please use at least BungeeCord #" + requiredBCBuild);

--- a/src/main/java/fr/Alphart/BAT/Modules/Core/LookupFormatter.java
+++ b/src/main/java/fr/Alphart/BAT/Modules/Core/LookupFormatter.java
@@ -142,21 +142,9 @@ public class LookupFormatter {
         final String last_ip = !"0.0.0.0".equals(pDetails.getLastIP())
                 ? ((displayIP) ? pDetails.getLastIP() : _("hiddenIp"))
                 : _("unknownIp");
-                
-        String name_history_list;
-        // Create a function for that or something better than a big chunk of code inside the lookup
-        if(ProxyServer.getInstance().getConfig().isOnlineMode()){
-            try{
-                name_history_list = Joiner.on("&e, &a").join(MojangAPIProvider.getPlayerNameHistory(pName));
-            }catch(final RuntimeException e){
-                name_history_list = "unable to fetch player's name history. Check the logs";
-                BAT.getInstance().getLogger().severe("An error occured while fetching " + pName + "'s name history from mojang servers."
-                        + "Please report this : ");
-                e.printStackTrace();
-            }
-        }else{
-            name_history_list = "offline server";
-        }
+
+        //Mojang no longer supports name history lookups
+        String name_history_list = "Deprecated.";
         
         int commentsNumber = pDetails.getComments().size();
         String last_comments = "";

--- a/src/main/java/fr/Alphart/BAT/database/DataSourceHandler.java
+++ b/src/main/java/fr/Alphart/BAT/database/DataSourceHandler.java
@@ -76,7 +76,7 @@ public class DataSourceHandler {
 			BAT.getInstance().getLogger().config("BoneCP is loaded !");
 		} catch (final SQLException e) {
 			e.printStackTrace();
-			BAT.getInstance().getLogger().severe("BAT encounters a problem during the initialization of the database connection."
+			BAT.getInstance().getLogger().severe("BAT encountered a problem during the initialization of the database connection."
 					+ " Please check your logins and database configuration.");
 			if(e.getCause() instanceof CommunicationsException){
 			    BAT.getInstance().getLogger().severe(e.getCause().getMessage());
@@ -108,7 +108,7 @@ public class DataSourceHandler {
 					+ "bat_database.db");
 			SQLiteConn.close();
 		} catch (SQLException e) {
-			BAT.getInstance().getLogger().severe("BAT encounters a problem during the initialization of the sqlite database connection.");
+			BAT.getInstance().getLogger().severe("BAT encountered a problem during the initialization of the sqlite database connection.");
 			if(e.getMessage() != null){
 				BAT.getInstance().getLogger().severe("Error message : " + e.getMessage());
 			}


### PR DESCRIPTION
Most of the incompatibility seems to have been with Yamler; however, I took this chance to upgrade several dependencies to newer versions to fix some vulnerabilities.

This can still only be built with Java 8, as the way it loads classes for things like SQLite seems to have been deprecated or otherwise changed in Java 9. I simply could not get it loading the class properly.